### PR TITLE
20/markdown support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem "functional-ruby"
 # admin panel
 gem "rails_admin", "~> 2.0"
 
+# markdown support 
+gem "redcarpet"
+
 # hotwire
 # gem 'hotwire-rails'
 

--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,9 @@ gem "functional-ruby"
 # admin panel
 gem "rails_admin", "~> 2.0"
 
-# markdown support 
-gem "redcarpet"
+# markdown support
+ gem "redcarpet"
+ gem "coderay", '~> 1.1'
 
 # hotwire
 # gem 'hotwire-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     redis (4.2.5)
     regexp_parser (1.8.2)
     remotipart (1.4.4)
@@ -419,6 +420,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.0)
   rails_admin (~> 2.0)
+  redcarpet
   redis (~> 4.0)
   sass-rails (>= 6)
   scenic

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,6 +403,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  coderay (~> 1.1)
   devise
   faker
   functional-ruby

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,22 @@
 module ApplicationHelper
+    class CodeRayify < Redcarpet::Render::HTML
+        def block_code(code, language)
+            CodeRay.scan(code, language || :text).div
+        end
+    end
+
     def markdown(content)
-        renderer = Redcarpet::Render::HTML.new(filter_html: true, hard_wrap:true)
-        markdown = Redcarpet::Markdown.new(renderer, extensions = {tables:true, fenced_code_block: true, underline:true, strikethrough:true, quote:true, highlight: true, superscript:true})
+        coderayified = CodeRayify.new(filter_html: true)
+        markdown = Redcarpet::Markdown.new(coderayified, extensions = { 
+                                                                    tables: true,
+                                                                    fenced_code_blocks: true, 
+                                                                    underline: true, 
+                                                                    strikethrough: true, 
+                                                                    quote: true, 
+                                                                    highlight: true, 
+                                                                    superscript: true,
+                                                                    footnotes: true
+                                                                  })
         markdown.render(content).html_safe
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
-    class CodeRayify < Redcarpet::Render::HTML
+    class CodeRayify < Redcarpet::Render::Safe
+        # uses html_escape flag to prevent html/xss injections
         def block_code(code, language)
             CodeRay.scan(code, language || :text).div
         end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+    def markdown(content)
+        renderer = Redcarpet::Render::HTML.new(filter_html: true, hard_wrap:true)
+        markdown = Redcarpet::Markdown.new(renderer, extensions = {tables:true, fenced_code_block: true, underline:true, strikethrough:true, quote:true, highlight: true, superscript:true})
+        markdown.render(content).html_safe
+    end
 end

--- a/app/views/nodes/_preview_topic.html.erb
+++ b/app/views/nodes/_preview_topic.html.erb
@@ -4,7 +4,7 @@
       <%= link_to node.title_w_default, node %>
     </p>
     <p class="border">
-      <%= node.content.body.slice(0, 200) if node.content.body %>
+      <%= markdown(node.content.body.slice(0, 200)) if node.content.body %>
     </p>
     <nav class="breadcrumb">
       <ul>

--- a/app/views/nodes/_view_comment.html.erb
+++ b/app/views/nodes/_view_comment.html.erb
@@ -12,7 +12,9 @@
           Date: <%= @node.created_at %>
         </div>
         <div class="panel-block">
-          <%= simple_format markdown(@node.content.body) %>
+          <div class="content">
+            <%= markdown(@node.content.body) %>
+          </div>
         </div>
       </nav>
       <div class="columns is-mobile">

--- a/app/views/nodes/_view_comment.html.erb
+++ b/app/views/nodes/_view_comment.html.erb
@@ -3,7 +3,7 @@
     <div class="column">
       <nav class="panel is-link">
         <div class="panel-heading">
-          <%= @node.title %>
+          <%= @node.title_w_default %>
         </div>
         <div class="panel-block">
           By: <%= @node.author.formatted_name || "Anonymous" %>
@@ -13,7 +13,7 @@
         </div>
         <div class="panel-block">
           <div class="content">
-            <%= markdown(@node.content.body) %>
+        <%= markdown(@node.content.body) if @node.content.body %>
           </div>
         </div>
       </nav>

--- a/app/views/nodes/_view_comment.html.erb
+++ b/app/views/nodes/_view_comment.html.erb
@@ -12,7 +12,7 @@
           Date: <%= @node.created_at %>
         </div>
         <div class="panel-block">
-          <%= @node.content.body %>
+          <%= simple_format markdown(@node.content.body) %>
         </div>
       </nav>
       <div class="columns is-mobile">

--- a/app/views/nodes/_view_comment_inline.html.erb
+++ b/app/views/nodes/_view_comment_inline.html.erb
@@ -7,7 +7,7 @@
   <% end %>
   <div class='comment-block'>
     <div class="content">
-      <%= markdown(node.content.body) %>
+      <%= markdown(node.content.body) if node.content.body %>
     </div>
   </div>
   <div class='comment-block is-small'>

--- a/app/views/nodes/_view_comment_inline.html.erb
+++ b/app/views/nodes/_view_comment_inline.html.erb
@@ -6,7 +6,9 @@
     </div>
   <% end %>
   <div class='comment-block'>
-    <%= node.content.body %>
+    <div class="content">
+      <%= markdown(node.content.body) %>
+    </div>
   </div>
   <div class='comment-block is-small'>
     <% anchor = "##{node.id}" %>

--- a/app/views/nodes/_view_topic.html.erb
+++ b/app/views/nodes/_view_topic.html.erb
@@ -16,7 +16,7 @@
       </div>
       <div class="panel-block">
         <div class="content">
-          <%= markdown(@node.content.body) %>
+          <%= markdown(@node.content.body) if @node.content.body %>
         </div>
       </div>
       <!-- <p class="panel-tabs has-text-left is-flex pl-1">

--- a/app/views/nodes/_view_topic.html.erb
+++ b/app/views/nodes/_view_topic.html.erb
@@ -15,8 +15,7 @@
         </div>
       </div>
       <div class="panel-block">
-        <%# todo: render markdown %>
-        <%= node.content.body %>
+        <%= simple_format markdown(@node.content.body) %>
       </div>
       <!-- <p class="panel-tabs has-text-left is-flex pl-1">
         <%# <%= link_to 'Delete', node_path(@node), class: "button is-warning", method: :delete, data: { confirm: "Are you sure?" } %>

--- a/app/views/nodes/_view_topic.html.erb
+++ b/app/views/nodes/_view_topic.html.erb
@@ -15,7 +15,9 @@
         </div>
       </div>
       <div class="panel-block">
-        <%= simple_format markdown(@node.content.body) %>
+        <div class="content">
+          <%= markdown(@node.content.body) %>
+        </div>
       </div>
       <!-- <p class="panel-tabs has-text-left is-flex pl-1">
         <%# <%= link_to 'Delete', node_path(@node), class: "button is-warning", method: :delete, data: { confirm: "Are you sure?" } %>


### PR DESCRIPTION
Since this works off of the better-views branch, would be good to first merge that once you've reviewed it. 

- [Redcarpet](https://github.com/vmg/redcarpet) is what is used to convert the markdown to html 
- [Coderay](https://github.com/rubychan/coderay) is used to support syntax highlighting in the fenced code blocks 