### PR TITLE
22/focus view

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -2,7 +2,7 @@ class NodesController < ApplicationController
   before_action :set_user
   before_action :set_node, only: []
   before_action :set_parent, only: [:new, :new_comment]
-  before_action :set_node_to_children_map, only: [:show, :subtree, :view_as]
+  before_action :set_node_to_children_map, only: [:show, :subtree, :view_as, :focus]
   before_action :authenticate_user!, only: [:new, :new_comment, :create]
 
   helper_method :current_user
@@ -23,6 +23,15 @@ class NodesController < ApplicationController
   def view_as
     @view_type = params[:view_name]
   end
+
+  # GET /focus/:node/on/:id
+  def focus
+    ancestors_map, @node = Node.ancestors_until_parent(params[:id], params[:node])
+    if @node.nil?
+      raise ActiveRecord::RecordNotFound, "Parent node (id: #{params[:id]}) does not connect to child node (id: #{params[:node]})."
+    end
+    @children_lookup = @children_lookup.merge(ancestors_map)
+  end 
 
   def subtree
     # TODO: permissions

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -111,6 +111,14 @@ class Node < ApplicationRecord
       arel_table
     end
 
+    def ancestors_until_parent(node_id, parent_id)
+      ancestors = Node.join_recursive { |q| q.start_with(id: node_id).connect_by(parent_id: :id).where('nodes.id >= ?', parent_id) }
+      ancestors_map = Hash.new { |h, k| h[k] = Array.new }
+      ancestors.each { |n| ancestors_map[n.parent_id] << n } 
+      branch_root = ancestors.find_by(id: parent_id)
+      return ancestors_map, branch_root
+    end
+
     def descendants_raw(node_id)
       Node.join_recursive { |q| q.start_with(id: node_id).connect_by(id: :parent_id) }
     end

--- a/app/views/nodes/_view_comment_inline.html.erb
+++ b/app/views/nodes/_view_comment_inline.html.erb
@@ -19,6 +19,7 @@
     <span class="mx-2"></span>
     <%# old reply link: reply_to_node_path(parent_id) %>
     <%= link_to "Reply", new_node_path(:parent_id => node.id), class: "button is-small is-link" %>
+    <%= link_to "Focus", focus_path(root_node_id, node.id), class: "button is-small is-link is-light" %>
     <%= link_to "Permalink", node, class: "button is-gray is-small ml-1" %>
   </div>
   <div class="comment-children">
@@ -26,7 +27,7 @@
       <% if depth_left > 0 && @children_lookup[node.id].count > 0 %>
         <%# todo: although @children_lookup[node.id] might have > 0 nodes, it doesn't mean it has all available children for the current user. also, there could be fewer children available to the user than .n_children. How do we handle both of these situations at once? %>
         <% @children_lookup[node.id].each do |child| %>
-          <%= render 'view_comment_inline', node: child, depth_left: depth_left - 1 %>
+          <%= render 'view_comment_inline', node: child, depth_left: depth_left - 1, root_node_id: root_node_id %>
         <% end %>
       <% else %>
         <h1 class="title is-size-5 red" style="margin-bottom: 0;">TODO: handle (<%= node.n_children %>) more children that we're not showing.</h1>

--- a/app/views/nodes/focus.html.erb
+++ b/app/views/nodes/focus.html.erb
@@ -4,14 +4,14 @@
     <nav class="panel">
       <div class="panel-heading has-background-primary-light is-flex">
         <div class="is-flex-grow-5">
-          <%= node.content.title %>
-          <%= link_to "../", node_path(node.parent_id), class: "is-small" unless node.parent_id.nil? %>
+          <%= @node.content.title %>
+          <%= link_to "../", node_path(@node.parent_id), class: "is-small" unless @node.parent_id.nil? %>
         </div>
         <div class="">
-          <% if current_user && node.user.id == current_user.id %>
-            <%= link_to 'Edit', edit_node_path(node), class: "button is-small" %>
+          <% if current_user && @node.user.id == current_user.id %>
+            <%= link_to 'Edit', edit_node_path(@node), class: "button is-small" %>
           <% end %>
-          <%= link_to 'Reply', reply_to_node_path(:parent_id => node.id), class: "button is-success is-small" %>
+          <%= link_to 'Reply', reply_to_node_path(:parent_id => @node.id), class: "button is-success is-small" %>
         </div>
       </div>
       <div class="panel-block">
@@ -19,23 +19,19 @@
           <%= markdown(@node.content.body) if @node.content.body %>
         </div>
       </div>
-      <!-- <p class="panel-tabs has-text-left is-flex pl-1">
-        <%# <%= link_to 'Delete', node_path(@node), class: "button is-warning", method: :delete, data: { confirm: "Are you sure?" } %>
-        <span class="is-flex-grow-4"></span>
-      </p> -->
       <div class="panel-block">
         <nav class="breadcrumb">
           <ul>
-            <li><%= link_to node.author.formatted_name, author_path(node.content.author_id) %></li>
-            <li><%= link_to node.user.username, user_path(node.author.user_id) %></li>
+            <li><%= link_to @node.author.formatted_name, author_path(@node.content.author_id) %></li>
+            <li><%= link_to @node.user.username, user_path(@node.author.user_id) %></li>
             <li class="is-active">
-              <a><%= node.created_at %> / <%= time_ago_in_words(node.created_at || DateTime.now) %> ago</a>
+              <a><%= @node.created_at %> / <%= time_ago_in_words(@node.created_at || DateTime.now) %> ago</a>
             </li>
             <li class="is-active">
-              <a>Children: <%= node.n_children %></a>
+              <a>Children: <%= @node.n_children %></a>
             </li>
             <li class="is-active">
-              <a>Descendants: <%= node.n_descendants %></a>
+              <a>Descendants: <%= @node.n_descendants %></a>
             </li>
           </ul>
         </nav>
@@ -43,6 +39,7 @@
     </nav>
   </div>
 </div>
+
 <% if @node.n_children > 0 %>
   <h3 class='title'>Replies:</h3>
   <h5 class='subtitle'>TOC:</h5>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get "/subtree/:id", to: "nodes#subtree", as: "subtree"
 
   get "/:id", to: "nodes#show", as: "node"
+  get "/focus/:node/on/:id", to: "nodes#focus", as: "focus"
 
   get "/view_as/:view_name/:id", to: "nodes#view_as", as: "view_as"
 end

--- a/lib/cff/node_faker.rb
+++ b/lib/cff/node_faker.rb
@@ -7,7 +7,7 @@ module Cff::NodeFaker
     Faker::Config.random = Random.new(0)
     @faker_users = [user, sub_user, general_user]
     @faker_root = create_node nil, "Faker Root", @root, body: "All faker nodes will be created under this node."
-    @faker_nested_root = create_node nil, "Faker Root Node", @root, body: "A nested thread of 500 replies will be created under this node."
+    @faker_nested_root = create_node nil, "Nested Faker Root", @root, body: "A nested thread of 500 replies will be created under this node."
 
     n_fake_nodes ||= 500
     n_fake_nodes = ENV["n_fake_nodes"]&.to_i || n_fake_nodes

--- a/lib/cff/node_faker.rb
+++ b/lib/cff/node_faker.rb
@@ -7,12 +7,26 @@ module Cff::NodeFaker
     Faker::Config.random = Random.new(0)
     @faker_users = [user, sub_user, general_user]
     @faker_root = create_node nil, "Faker Root", @root, body: "All faker nodes will be created under this node."
+    @faker_nested_root = create_node nil, "Faker Root Node", @root, body: "A nested thread of 500 replies will be created under this node."
 
     n_fake_nodes ||= 500
     n_fake_nodes = ENV["n_fake_nodes"]&.to_i || n_fake_nodes
     Rails::logger.warn "n_fake_nodes set to #{n_fake_nodes}. set env var 'n_fake_nodes' to overwrite."
     self.run_faker_inner(n_fake_nodes)
+    self.run_faker_deep_replies(n_fake_nodes)
   end
+
+  def run_faker_deep_replies(n_fake_nodes = nil) 
+    @curr_parent = @faker_nested_root
+    Benchmark.bm do |m| 
+      for i in 1..n_fake_nodes do 
+        title = Faker::Lorem.sentence(word_count: 3, random_words_to_add: 4)
+        body = Faker::Lorem.paragraph(sentence_count: 2, supplemental: false, random_sentences_to_add: 4)
+        @new_parent = create_node nil, title, @curr_parent, body: body
+        @curr_parent = @new_parent
+      end 
+    end 
+  end 
 
   def run_faker_inner(n_fake_nodes = nil)
     # default: 88k nodes with branching factor of 3. Approx uniformly max depth of 10


### PR DESCRIPTION
Added a focus button on each comment under a post. When you click on it, it'll bring you to a new page where you are able to view only the relevant posts associated with that comment. 
Relevant posts include: 
- the parent post 
- all the nodes in between the parent and the focus node 
- the focus post 
- all children of the focus 

illustration taken from microblog here: 
![image](https://user-images.githubusercontent.com/77727599/107893783-3bd1c680-6f81-11eb-9601-ca49a38f3932.png)
note from max on diagram: 

> Yeah, tho where you have "reply 1" there might be a chain of nodes between "main topic" and "post" (F)

Essentially like the show context feature in reddit. 