### PR TITLE
30/UI tag selection

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -63,12 +63,14 @@ class NodesController < ApplicationController
     @node = Node.new(node_params.merge :author => @author)
     @cv = ContentVersion.new(cv_params.merge :node => @node, :author => @author)
     @tags = []
-    tag_decl_ids.each do |anchored_tag|
-      @anchored_tag_decl = TagDecl.find(anchored_tag)
-      @tag_decl = TagDecl.new(:user => @user, :target => @node, :anchored => @anchored_tag_decl, :tag => "include_" + @anchored_tag_decl.tag)
-      @tags << @tag_decl
-    end 
-    
+    if !tag_decl_ids.nil? 
+      tag_decl_ids.each do |anchored_tag|
+        @anchored_tag_decl = TagDecl.find(anchored_tag)
+        @tag_decl = TagDecl.new(:user => @user, :target => @node, :anchored => @anchored_tag_decl, :tag => "include_" + @anchored_tag_decl.tag)
+        @tags << @tag_decl
+      end
+    end
+
     respond_to do |format|
       begin 
         ActiveRecord::Base.transaction do 

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -63,9 +63,9 @@ class NodesController < ApplicationController
     @node = Node.new(node_params.merge :author => @author)
     @cv = ContentVersion.new(cv_params.merge :node => @node, :author => @author)
     @tags = []
-    tag_decl_ids.reject(&:empty?).each do |anchored_tag|
+    tag_decl_ids.each do |anchored_tag|
       @anchored_tag_decl = TagDecl.find(anchored_tag)
-      @tag_decl = TagDecl.new(:user => @user, :target => @node, :anchored => @anchored_tag_decl, :tag => :include_on_blog)
+      @tag_decl = TagDecl.new(:user => @user, :target => @node, :anchored => @anchored_tag_decl, :tag => "include_" + @anchored_tag_decl.tag)
       @tags << @tag_decl
     end 
     

--- a/app/javascript/packs/tags.js
+++ b/app/javascript/packs/tags.js
@@ -1,0 +1,26 @@
+import $ from 'jquery';
+
+function add_to_selected_tags(e) {
+  var text = e.target[e.target.selectedIndex].text
+  var id = e.target.value
+  if (document.getElementById(text + "-tag") == null && text) {
+    var tag_html = "<span type='select' class='tag is-medium' value=" + id + " id=" + text + "-tag>" + 
+                      text + 
+                      "<button type='button' class='delete is-small' id='tag-delete'></button>" + 
+                      "<input type='hidden' name='node[tag_decl_ids][]' multiple=true value=" + id + ">" + 
+                   "</span> "
+    $('.field#selected-tags').append(tag_html)
+  }
+}
+
+function remove_from_selected_tags(e) {
+  e.target.parentElement.remove()
+}
+
+$(() => 
+  $('.select#tags-select').on('change', (e) => add_to_selected_tags(e))
+);
+
+$(() => 
+  $('body').on('click', 'button#tag-delete', (e) => remove_from_selected_tags(e))
+);

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,10 +16,16 @@ class User < ApplicationRecord
 
   has_one :users_group
 
-  after_create :create_user_author, :refresh_users_groups
+  after_create :create_user_author, :refresh_users_groups, :add_default_tags
 
   def create_user_author
     self.authors << Author.create(user: self)
+  end
+
+  def add_default_tags
+    # default blog tag 
+    node = Node.create! 
+    TagDecl.find_or_create_by! :anchored => node, :target => self, :tag => :blog_index, :user => self
   end
 
   def refresh_users_groups

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,10 @@ class User < ApplicationRecord
     self.users_group.groups_in_database
   end
 
+  def get_targeting_tags 
+    self.targeting_tags
+  end 
+
   def groups_arel
     throw "deprecated? replaced with user_groups view"
     uts = UserTag.table

--- a/app/views/nodes/_form_new_topic.html.erb
+++ b/app/views/nodes/_form_new_topic.html.erb
@@ -18,11 +18,21 @@
     <%= form.text_field :title, class: "input" %>
   </div>
   <%= form.label :author_id, class: "label" %>
-  <div class="select">
-    <%= form.select :author_id, [["Public", true], ["Pseudonyms", false]].to_h {|p|
-      [p[0], @user.authors.where(public: p[1]).collect {|a| [a.formatted_name, a.id]}]
-    }, class: "" %>
+
+  <div class="field">  
+    <div class="select">
+      <%= form.select :author_id, [["Public", true], ["Pseudonyms", false]].to_h {|p|
+        [p[0], @user.authors.where(public: p[1]).collect {|a| [a.formatted_name, a.id]}]
+      }, class: "" %>
+    </div>
   </div>
+  
+  <div class="field"> 
+    <div class="select is-multiple" onChange=testing(event) >
+      <%= form.select :tag_decl_ids, @user.get_targeting_tags.collect { |t| [t.tag, t.id]} , {}, {multiple: true} %>
+    </div>
+  </div>
+
   <div class="field">
     <%= form.label :body, class: "label" %>
     <%= form.text_area :body, class: "textarea", size: "80x10" %>

--- a/app/views/nodes/_form_new_topic.html.erb
+++ b/app/views/nodes/_form_new_topic.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_pack_tag 'tags' %>
 <%= form_with(model: node) do |form| %>
   <% if node.errors.any? %>
     <div id="message is-danger">
@@ -26,10 +27,14 @@
       }, class: "" %>
     </div>
   </div>
+
+  <%= form.label :targeting_tags, class:"label" %>
+  <div class="field" id="selected-tags">
+  </div>
   
   <div class="field"> 
-    <div class="select is-multiple" onChange=testing(event) >
-      <%= form.select :tag_decl_ids, @user.get_targeting_tags.collect { |t| [t.tag, t.id]} , {}, {multiple: true} %>
+    <div class="select" id="tags-select" >
+      <%= form.select :tag_decl_id, @user.get_targeting_tags.collect { |t| [t.tag, t.id]}, :include_blank => true %>
     </div>
   </div>
 

--- a/app/views/nodes/_preview_topic.html.erb
+++ b/app/views/nodes/_preview_topic.html.erb
@@ -8,7 +8,7 @@
     </p>
     <nav class="breadcrumb">
       <ul>
-        <li><%= link_to node.author.formatted_name, author_path(node.author_id) %></li>
+        <li><%= link_to node.author.formatted_name, author_path(node.author.id) %></li>
         <li><%= link_to node.user.username, user_path(node.user) %></li>
         <li class="is-active">
           <a><%= node.created_at %> / <%= time_ago_in_words(node.created_at || DateTime.now) %> ago</a>

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "cfforum",
   "private": true,
   "dependencies": {
+    "@babel/core": "^7.13.1",
+    "@babel/preset-env": "^7.13.5",
     "@hotwired/turbo-rails": "^7.0.0-beta.4",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.2.1",
+    "jquery": "^3.5.1",
     "stimulus": "^2.0.0"
   },
   "version": "0.1.0",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/77727599/109251642-eb3f5080-783f-11eb-991d-dbaee2d9a10f.png)

* When creating a new post, the user can select 0 or more of their targeting tags to tag their post with 
* Dropdown with tag pop ups and ability to delete tag 
* On form post, it'll create a new tag decl for each tag that has been selected - the tag that has been selected becomes the anchoring tag, with the new post (node) being the target tag. 

Notes: 
* The way I could get the UI tagging to work is to have a hidden field for each tag - I'm unsure if this is the best practise to do it so open to suggestions on how it could be better written 
* Issue 29 is also in this PR with the default blog tag that is created for each user 
* Currently on post creation, it will create a new tag decl w the tag string being "include_<tag string>" - this is an assumption that will need to change I think. What if the user wants a "related to" link, instead of a "include" link? 